### PR TITLE
lodash dependency updated

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/ArkeologeN/pipl",
   "dependencies": {
-    "lodash": "~2.4.1",
+    "lodash": "~4.17.10",
     "request": "~2.83.0"
   }
 }


### PR DESCRIPTION
```
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ Low           │ Prototype Pollution                                          │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ lodash                                                       │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Patched in    │ >=4.17.5                                                     │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ pipl                                                         │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ pipl > lodash                                                │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://nodesecurity.io/advisories/577                       │
└───────────────┴──────────────────────────────────────────────────────────────┘
```